### PR TITLE
fix weather schema

### DIFF
--- a/lambda/redshiftinit/schema/weather.sql
+++ b/lambda/redshiftinit/schema/weather.sql
@@ -4,7 +4,7 @@ DROP TABLE IF EXISTS weather CASCADE;
 
 CREATE TABLE weather (
     weather_date DATE,
-    prefecture VARCHAR(10),
+    prefecture VARCHAR(20),
     temp_max INT NOT NULL,
     temp_min INT NOT NULL,
     temp_ave INT NOT NULL,


### PR DESCRIPTION
fix "String length exceeds ddl length" when it tries to load long prefecture name